### PR TITLE
feat: default seeding goals for new torrents

### DIFF
--- a/src/lib/torrents.ts
+++ b/src/lib/torrents.ts
@@ -75,6 +75,10 @@ export interface GlobalTorrentSettings {
 	uploadLimitBps: number | null;
 	maxActiveDownloads: number | null;
 	maxActiveSeeders: number | null;
+	defaultRatioGoal: number | null;
+	defaultSeedTimeGoalMinutes: number | null;
+	defaultStopOnRatio: boolean;
+	defaultStopOnSeedTime: boolean;
 }
 
 export interface AppTorrentSettingsSummary {

--- a/src/routes/api/torrents/control.ts
+++ b/src/routes/api/torrents/control.ts
@@ -5,6 +5,10 @@ interface GlobalControlBody {
 	uploadLimitBps?: number | null;
 	maxActiveDownloads?: number | null;
 	maxActiveSeeders?: number | null;
+	defaultRatioGoal?: number | null;
+	defaultSeedTimeGoalMinutes?: number | null;
+	defaultStopOnRatio?: boolean;
+	defaultStopOnSeedTime?: boolean;
 }
 
 export const Route = createFileRoute("/api/torrents/control")({
@@ -22,6 +26,10 @@ export const Route = createFileRoute("/api/torrents/control")({
 					uploadLimitBps: payload.uploadLimitBps,
 					maxActiveDownloads: payload.maxActiveDownloads,
 					maxActiveSeeders: payload.maxActiveSeeders,
+					defaultRatioGoal: payload.defaultRatioGoal,
+					defaultSeedTimeGoalMinutes: payload.defaultSeedTimeGoalMinutes,
+					defaultStopOnRatio: payload.defaultStopOnRatio,
+					defaultStopOnSeedTime: payload.defaultStopOnSeedTime,
 				});
 				return Response.json({ global });
 			},

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -32,6 +32,10 @@ function Home() {
 		uploadLimitBps: null,
 		maxActiveDownloads: null,
 		maxActiveSeeders: null,
+		defaultRatioGoal: null,
+		defaultSeedTimeGoalMinutes: null,
+		defaultStopOnRatio: false,
+		defaultStopOnSeedTime: false,
 	});
 	const [loading, setLoading] = useState(true);
 	const [busyId, setBusyId] = useState<string | null>(null);

--- a/src/routes/manage.tsx
+++ b/src/routes/manage.tsx
@@ -40,6 +40,10 @@ function ManageRoute() {
 	const [globalUpInput, setGlobalUpInput] = useState("");
 	const [maxDownloadsInput, setMaxDownloadsInput] = useState("");
 	const [maxSeedersInput, setMaxSeedersInput] = useState("");
+	const [defaultRatioInput, setDefaultRatioInput] = useState("");
+	const [defaultSeedMinutesInput, setDefaultSeedMinutesInput] = useState("");
+	const [defaultStopOnRatio, setDefaultStopOnRatio] = useState(false);
+	const [defaultStopOnSeedTime, setDefaultStopOnSeedTime] = useState(false);
 
 	useEffect(() => {
 		let active = true;
@@ -58,6 +62,10 @@ function ManageRoute() {
 				setGlobalUpInput(toLimitInput(next.global.uploadLimitBps));
 				setMaxDownloadsInput(toQueueInput(next.global.maxActiveDownloads));
 				setMaxSeedersInput(toQueueInput(next.global.maxActiveSeeders));
+				setDefaultRatioInput(toRatioInput(next.global.defaultRatioGoal));
+				setDefaultSeedMinutesInput(toQueueInput(next.global.defaultSeedTimeGoalMinutes));
+				setDefaultStopOnRatio(next.global.defaultStopOnRatio);
+				setDefaultStopOnSeedTime(next.global.defaultStopOnSeedTime);
 				setError(null);
 			} else {
 				setError(
@@ -100,6 +108,10 @@ function ManageRoute() {
 					setGlobalUpInput(toLimitInput(payload.global.uploadLimitBps));
 					setMaxDownloadsInput(toQueueInput(payload.global.maxActiveDownloads));
 					setMaxSeedersInput(toQueueInput(payload.global.maxActiveSeeders));
+					setDefaultRatioInput(toRatioInput(payload.global.defaultRatioGoal));
+					setDefaultSeedMinutesInput(toQueueInput(payload.global.defaultSeedTimeGoalMinutes));
+					setDefaultStopOnRatio(payload.global.defaultStopOnRatio);
+					setDefaultStopOnSeedTime(payload.global.defaultStopOnSeedTime);
 				}
 				setLoading(false);
 			} catch {
@@ -173,6 +185,10 @@ function ManageRoute() {
 				uploadLimitBps: fromLimitInput(globalUpInput),
 				maxActiveDownloads: fromQueueInput(maxDownloadsInput),
 				maxActiveSeeders: fromQueueInput(maxSeedersInput),
+				defaultRatioGoal: fromRatioInput(defaultRatioInput),
+				defaultSeedTimeGoalMinutes: fromQueueInput(defaultSeedMinutesInput),
+				defaultStopOnRatio,
+				defaultStopOnSeedTime,
 			});
 			setError(null);
 		} catch (requestError) {
@@ -290,6 +306,44 @@ function ManageRoute() {
 									onChange={(event) => setMaxSeedersInput(event.target.value)}
 									placeholder="Unlimited"
 								/>
+								<label className="tide-label" htmlFor="default-ratio">
+									Default ratio goal
+								</label>
+								<input
+									id="default-ratio"
+									className="tide-input"
+									value={defaultRatioInput}
+									onChange={(event) => setDefaultRatioInput(event.target.value)}
+									placeholder="No goal"
+								/>
+								<label className="tide-label" htmlFor="default-seed-minutes">
+									Default seed minutes goal
+								</label>
+								<input
+									id="default-seed-minutes"
+									className="tide-input"
+									value={defaultSeedMinutesInput}
+									onChange={(event) => setDefaultSeedMinutesInput(event.target.value)}
+									placeholder="No goal"
+								/>
+								<label className="tide-toggle" htmlFor="default-stop-on-ratio">
+									<input
+										id="default-stop-on-ratio"
+										type="checkbox"
+										checked={defaultStopOnRatio}
+										onChange={(event) => setDefaultStopOnRatio(event.target.checked)}
+									/>
+									<span>Stop new torrents on ratio goal by default</span>
+								</label>
+								<label className="tide-toggle" htmlFor="default-stop-on-seed-time">
+									<input
+										id="default-stop-on-seed-time"
+										type="checkbox"
+										checked={defaultStopOnSeedTime}
+										onChange={(event) => setDefaultStopOnSeedTime(event.target.checked)}
+									/>
+									<span>Stop new torrents on seed-time goal by default</span>
+								</label>
 								<CoralButton type="submit" disabled={busy}>
 									Save settings
 								</CoralButton>
@@ -636,6 +690,19 @@ function fromQueueInput(value: string) {
 	const trimmed = value.trim();
 	if (!trimmed) return null;
 	const parsed = Number.parseInt(trimmed, 10);
+	if (!Number.isFinite(parsed) || parsed < 0) return null;
+	return parsed;
+}
+
+function toRatioInput(value: number | null | undefined) {
+	if (value == null) return "";
+	return String(value);
+}
+
+function fromRatioInput(value: string) {
+	const trimmed = value.trim();
+	if (!trimmed) return null;
+	const parsed = Number.parseFloat(trimmed);
 	if (!Number.isFinite(parsed) || parsed < 0) return null;
 	return parsed;
 }

--- a/src/server/modules/torrent/manager.ts
+++ b/src/server/modules/torrent/manager.ts
@@ -307,12 +307,18 @@ function getMemoryGuardSettings(): MemoryGuardSettings {
 	};
 }
 
-function toSafeGlobalSettings(value: Partial<GlobalTorrentSettings> | null | undefined) {
+function toSafeGlobalSettings(
+	value: Partial<GlobalTorrentSettings> | null | undefined,
+): GlobalTorrentSettings {
 	return {
 		downloadLimitBps: clampMaybeNumber(value?.downloadLimitBps),
 		uploadLimitBps: clampMaybeNumber(value?.uploadLimitBps),
 		maxActiveDownloads: clampMaybeInteger(value?.maxActiveDownloads),
 		maxActiveSeeders: clampMaybeInteger(value?.maxActiveSeeders),
+		defaultRatioGoal: clampMaybeNumber(value?.defaultRatioGoal),
+		defaultSeedTimeGoalMinutes: clampMaybeInteger(value?.defaultSeedTimeGoalMinutes),
+		defaultStopOnRatio: Boolean(value?.defaultStopOnRatio),
+		defaultStopOnSeedTime: Boolean(value?.defaultStopOnSeedTime),
 	};
 }
 
@@ -324,10 +330,10 @@ function defaultControlState(queueOrder: number): TorrentControlState {
 		queueOrder,
 		downloadLimitBps: null,
 		uploadLimitBps: null,
-		ratioGoal: null,
-		seedTimeGoalMinutes: null,
-		stopOnRatio: false,
-		stopOnSeedTime: false,
+		ratioGoal: persistedGlobal.defaultRatioGoal,
+		seedTimeGoalMinutes: persistedGlobal.defaultSeedTimeGoalMinutes,
+		stopOnRatio: persistedGlobal.defaultStopOnRatio,
+		stopOnSeedTime: persistedGlobal.defaultStopOnSeedTime,
 		trackerUrls: [],
 		addedAt: new Date().toISOString(),
 		doneAt: null,
@@ -1201,6 +1207,22 @@ export function updateGlobalSettings(input: Partial<GlobalTorrentSettings>) {
 			input.maxActiveSeeders === undefined
 				? persistedGlobal.maxActiveSeeders
 				: clampMaybeInteger(input.maxActiveSeeders),
+		defaultRatioGoal:
+			input.defaultRatioGoal === undefined
+				? persistedGlobal.defaultRatioGoal
+				: clampMaybeNumber(input.defaultRatioGoal),
+		defaultSeedTimeGoalMinutes:
+			input.defaultSeedTimeGoalMinutes === undefined
+				? persistedGlobal.defaultSeedTimeGoalMinutes
+				: clampMaybeInteger(input.defaultSeedTimeGoalMinutes),
+		defaultStopOnRatio:
+			input.defaultStopOnRatio === undefined
+				? persistedGlobal.defaultStopOnRatio
+				: Boolean(input.defaultStopOnRatio),
+		defaultStopOnSeedTime:
+			input.defaultStopOnSeedTime === undefined
+				? persistedGlobal.defaultStopOnSeedTime
+				: Boolean(input.defaultStopOnSeedTime),
 	};
 
 	torrentClient.throttleDownload(persistedGlobal.downloadLimitBps ?? -1);

--- a/src/server/modules/torrent/store.ts
+++ b/src/server/modules/torrent/store.ts
@@ -100,6 +100,10 @@ export function loadPersistedGlobalSettings() {
 		uploadLimitBps: null,
 		maxActiveDownloads: null,
 		maxActiveSeeders: null,
+		defaultRatioGoal: null,
+		defaultSeedTimeGoalMinutes: null,
+		defaultStopOnRatio: false,
+		defaultStopOnSeedTime: false,
 	});
 }
 

--- a/src/server/modules/torrent/types.ts
+++ b/src/server/modules/torrent/types.ts
@@ -97,6 +97,10 @@ export interface GlobalTorrentSettings {
 	uploadLimitBps: number | null;
 	maxActiveDownloads: number | null;
 	maxActiveSeeders: number | null;
+	defaultRatioGoal: number | null;
+	defaultSeedTimeGoalMinutes: number | null;
+	defaultStopOnRatio: boolean;
+	defaultStopOnSeedTime: boolean;
 }
 
 export interface AppTorrentSettingsSummary {

--- a/src/styles.css
+++ b/src/styles.css
@@ -476,6 +476,14 @@
   font-size: 0.82rem;
 }
 
+.tide-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--color-ink-muted);
+}
+
 .tide-global-footer {
   padding-top: 0.15rem;
   border-top: 1px solid var(--color-border);


### PR DESCRIPTION
## Summary

- Adds four global defaults that are applied to a torrent's control state when it is first created: `defaultRatioGoal`, `defaultSeedTimeGoalMinutes`, `defaultStopOnRatio`, `defaultStopOnSeedTime`.
- Persists them through the existing `torrent.global` SQLite setting and exposes them via the `/api/torrents/control` endpoint.
- Surfaces the four fields (two inputs + two toggles) in the **Engine settings** card on `/manage`.

Existing torrents are untouched — defaults only seed freshly created `TorrentControlState`s. Per-torrent overrides keep working as before.

Closes #9

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm test`
- [ ] Manual: set defaults on `/manage`, add a new magnet, confirm new torrent's ratio/seed-time goals + stop toggles match the defaults
- [ ] Manual: confirm changing defaults later does not retroactively mutate existing torrents

🤖 Generated with [Claude Code](https://claude.com/claude-code)